### PR TITLE
Filter common publications according to tag setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ For frequent external collaborators, it is nice to have their names in author li
 
 ### Add tag
 
-Tags are used to categorize papers. They are collected in `_data/tags.yml`. Add an abbreviation which appears next to the papers and talks and a description which appears upon clicking on the abbreviation here. Note that the `ST` tag is used to filter string theory papers.
+Tags are used to categorize papers. They are collected in `_data/tags.yml`. Add an abbreviation which appears next to the papers and talks and a description which appears upon clicking on the abbreviation here. `ml-relevant` can be `true` or `false` and, if true, let's a publication containing such a tag appear on the common publication page. Note that the `ST` tag is used to filter string theory papers.
 
 
 ## To do

--- a/_data/tags.yml
+++ b/_data/tags.yml
@@ -1,14 +1,20 @@
 - short: NTK
   long: Neural Tangent Kernel
+  ml-relevant: true
   # link:
 - short: ENN
   long: Equivariant Neural Networks
+  ml-relevant: true
   # link:
 - short: GDL
   long: Geometric Deep Learning
+  ml-relevant: true
 - short: XAI
   long: Explainable AI
+  ml-relevant: true
 - short: SCV
   long: Spherical Computer Vision  
+  ml-relevant: true
 - short: ST
   long: String Theory
+  ml-relevant: false

--- a/_layouts/member.html
+++ b/_layouts/member.html
@@ -71,9 +71,7 @@ layout: default
         {% assign pub = item[1] %}
         {% assign match = pub.author | where: 'family', page.last_name | first %}
         {% if match %}
-	{% unless pub.tags contains "ST" %}
         {% assign pubs = pubs | push: pub %}
-	{% endunless %}
         {% endif %}
         {% endfor %}
 
@@ -94,9 +92,7 @@ layout: default
         {% for item in site.data.talks %}
         {% assign talk = item[1] %}
         {% if talk.speaker.last_name == page.last_name %}
-	{% unless talk.tags contains "ST" %}
         {% assign talks = talks | push: talk %}
-	{% endunless %}
         {% endif %}
         {% endfor %}
 
@@ -105,54 +101,6 @@ layout: default
 
         {% unless talks == empty %}
         <h2 id="Talks">Talks</h2>
-
-        {% for talk in talks %}
-        {% include talk.html talk=talk id=forloop.index %}
-        {% endfor %}
-
-        {% endunless %}
-
-
-	{% assign st_pubs = "" | split: "," %}
-	{% for item in site.data.publications %}
-        {% assign pub = item[1] %}
-        {% assign match = pub.author | where: 'family', page.last_name | first %}
-        {% if match %}
-          {% if pub.tags contains "ST" %}
-            {% assign st_pubs = st_pubs | push: pub %}
-          {% endif %}
-	{% endif %}
-        {% endfor %}
-
-        {% assign st_pubs = st_pubs | sort: "issued" | reverse %}
-
-        {% unless st_pubs == empty %}
-
-        <h2 id="StringTheoryPublications">String Theory Publications</h2>
-
-        {% for st_pub in st_pubs %}
-        {% include publication.html pub=st_pub id=forloop.index %}
-        {% endfor %}
-
-        {% endunless %}
-
-
-	
-	{% assign talks = "" | split: "," %}
-        {% for item in site.data.talks %}
-        {% assign talk = item[1] %}
-        {% if talk.speaker.last_name == page.last_name %}
-	{% if talk.tags contains "ST" %}
-        {% assign talks = talks | push: talk %}
-	{% endif %}
-        {% endif %}
-        {% endfor %}
-
-
-        {% assign talks = talks | sort: "date" | reverse %}
-
-        {% unless talks == empty %}
-        <h2 id="StringTheoryTalks">String Theory Talks</h2>
 
         {% for talk in talks %}
         {% include talk.html talk=talk id=forloop.index %}

--- a/_pages/publications.html
+++ b/_pages/publications.html
@@ -3,18 +3,25 @@ layout: topic
 title: Publications
 ---
 
+{% assign ml_tags = site.data.tags | where: 'ml-relevant', true %}
+
+
 
 {% assign pubs = "" | split: "," %}
 {% for item in site.data.publications %}
     {% assign pub = item[1] %}
     {% assign pub.issued = pub.issued | date: "%Y-%m-%d" %}
-    {% assign pubs = pubs | push: pub %}
+
+    {% for ml_tag in ml_tags %}
+      {% if pub.tags contains ml_tag.short %}
+        {% assign pubs = pubs | push: pub %}
+        {% break %}
+      {% endif %}
+    {% endfor %}
 {% endfor %}
 
 {% assign pubs = pubs | sort: "issued" | reverse %}
 
 {% for pub in pubs%}
-  {% unless pub.tags contains "ST" %}
-    {% include publication.html pub=pub id=forloop.index %}
-  {% endunless %}
+  {% include publication.html pub=pub id=forloop.index %}
 {% endfor %}


### PR DESCRIPTION
tags now have `ml-relevant` as part of their definition, which is used to show only `ml-relevant` tags on the common publication page.