### PR TITLE
Fixed AI4SCI -> ML4SCI tags

### DIFF
--- a/_data/talks/2025-10-29-jan-gerken.yml
+++ b/_data/talks/2025-10-29-jan-gerken.yml
@@ -13,4 +13,4 @@ speaker:
 tags:
   - NTK
   - ENN
-  - AI4SCI
+  - ML4SCI

--- a/_data/talks/2025-12-09-jan-gerken.yml
+++ b/_data/talks/2025-12-09-jan-gerken.yml
@@ -13,8 +13,8 @@ slides: /downloads/slides/2025-12-09-jan-gerken.pdf
 video: 
 speaker:
     first_name: Jan E.
-    last_name: Gerken  
+    last_name: Gerken
 tags:
   - NTK
   - ENN
-  - AI4SCI
+  - ML4SCI


### PR DESCRIPTION
@JanEGerken the `ML4SCI` tag was used before while the `AI4SCI` tag that you used has not been defined yet. I unified it to `ML4SCI`, let me know if that's okay.